### PR TITLE
[glesshadercache] link against zlib

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ GLESSHADERCACHE_PACKAGES = glesv2 gl
 
 CFLAGS = -O2 $(shell pkg-config --cflags $(PACKAGES))
 LIBS = $(shell pkg-config --libs $(PACKAGES))
-GLESSHADERCACHE_LIBS = $(shell pkg-config --libs $(GLESSHADERCACHE_PACKAGES))
+GLESSHADERCACHE_LIBS = $(shell pkg-config --libs $(GLESSHADERCACHE_PACKAGES)) -lz
 
 SYMLINKS = \
 	android_bootctl \


### PR DESCRIPTION
Fixes: symbol lookup error: /lib/aarch64-linux-gnu/libglesshadercache.so: undefined symbol: crc32