### PR TITLE
[halium-wrappers] android-service: Always create timestamp file

### DIFF
--- a/src/android-service.sh
+++ b/src/android-service.sh
@@ -17,7 +17,11 @@ current_status() {
 }
 
 start() {
-	[ "$(current_status)" == "running" ] && return 0
+	if [ "$(current_status)" == "running" ]
+	then
+		touch ${ANDROID_SERVICE_STAMP}
+		return 0
+	fi
 
 	# Start operation is weird since it's kickstarted by Android's
 	# init - thus we assume that if ${ANDROID_SERVICE_STAMP} doesn't


### PR DESCRIPTION
Otherwise on startup, if service is started by Android's init before systemd unit, we will not be able to restart the service later.